### PR TITLE
(BKR-549) Add answers for 2016.1

### DIFF
--- a/lib/beaker-answers/versions/version20161.rb
+++ b/lib/beaker-answers/versions/version20161.rb
@@ -1,0 +1,13 @@
+require 'beaker-answers/versions/version20153'
+
+module BeakerAnswers
+  # This class provides answer file information for PE version 2016.1
+  #
+  # @api private
+  class Version20161 < Version20153
+    # The version of PE that this set of answers is appropriate for
+    def self.pe_version_matcher
+      /\A2016\.1/
+    end
+  end
+end


### PR DESCRIPTION
This is just to get the initial pipelines up and running; there are no
answers new to 2016.1 yet, so it will just inherit the_answers generated
by Version20153.