### PR TITLE
(maint) Add q_use_application_services question

### DIFF
--- a/lib/beaker-answers/versions/version20153.rb
+++ b/lib/beaker-answers/versions/version20153.rb
@@ -23,11 +23,13 @@ module BeakerAnswers
         :q_orchestrator_database_user     => answer_for(@options, :q_orchestrator_database_user),
         :q_orchestrator_database_password => "'#{answer_for(@options, :q_orchestrator_database_password)}'",
       }
+
       the_answers[master.name].merge!(orchestrator_db)
       the_answers[database.name].merge!(orchestrator_db)
 
       the_answers[master.name][:q_database_host] = answer_for(@options, :q_database_host, database.to_s)
       the_answers[master.name][:q_database_port] = answer_for(@options, :q_database_port)
+      the_answers[master.name][:q_use_application_services] = "'#{answer_for(@options, :q_use_application_services, 'y')}'"
 
       the_answers
     end


### PR DESCRIPTION
Currently in integration CI all installs are not setting the
q_use_application_services answer. When that answer is set to nothing
the pe-classification script does not enable application services.

This PR will cause at least the pre-upgrade integration to fail. This is probably okay for now because it is actually exposing a legitimate bug and should be merged in regardless of the state of this job.