### PR TITLE
(PE-12849) Add q_use_application_services to console

### DIFF
--- a/lib/beaker-answers/versions/version20153.rb
+++ b/lib/beaker-answers/versions/version20153.rb
@@ -17,6 +17,7 @@ module BeakerAnswers
 
       master = only_host_with_role(@hosts, 'master')
       database = only_host_with_role(@hosts, 'database')
+      console = only_host_with_role(@hosts, 'dashboard')
 
       orchestrator_db = {
         :q_orchestrator_database_name     => answer_for(@options, :q_orchestrator_database_name),
@@ -30,6 +31,7 @@ module BeakerAnswers
       the_answers[master.name][:q_database_host] = answer_for(@options, :q_database_host, database.to_s)
       the_answers[master.name][:q_database_port] = answer_for(@options, :q_database_port)
       the_answers[master.name][:q_use_application_services] = "'#{answer_for(@options, :q_use_application_services, 'y')}'"
+      the_answers[console.name][:q_use_application_services] = "'#{answer_for(@options, :q_use_application_services, 'y')}'"
 
       the_answers
     end

--- a/lib/beaker-answers/versions/version20153.rb
+++ b/lib/beaker-answers/versions/version20153.rb
@@ -30,8 +30,8 @@ module BeakerAnswers
 
       the_answers[master.name][:q_database_host] = answer_for(@options, :q_database_host, database.to_s)
       the_answers[master.name][:q_database_port] = answer_for(@options, :q_database_port)
-      the_answers[master.name][:q_use_application_services] = "'#{answer_for(@options, :q_use_application_services, 'y')}'"
-      the_answers[console.name][:q_use_application_services] = "'#{answer_for(@options, :q_use_application_services, 'y')}'"
+      the_answers[master.name][:q_use_application_services] = answer_for(@options, :q_use_application_services, 'y')
+      the_answers[console.name][:q_use_application_services] = answer_for(@options, :q_use_application_services, 'y')
 
       the_answers
     end

--- a/spec/beaker-answers/beaker-answers_spec.rb
+++ b/spec/beaker-answers/beaker-answers_spec.rb
@@ -350,6 +350,11 @@ describe BeakerAnswers::Version20153 do
     expect( @answers['vm3'][:q_orchestrator_database_user] ).to be === 'Orc3Str8R'
     expect( @answers['vm3'][:q_orchestrator_database_password] ).to be === "'~!@#$%^*-/ aZ'"
   end
+
+  it 'should add q_use_application_services answers to master and console' do
+    expect( @answers['vm1'][:q_use_application_services] ).to be === 'y'
+    expect( @answers['vm2'][:q_use_application_services] ).to be === 'y'
+  end
 end
 
 describe BeakerAnswers::Version32 do


### PR DESCRIPTION
Both the master and console must be given the
`q_use_application_services` answer, since the console
needs to know that it needs classify the orchestrator.