### PR TITLE
(BKR-763) Supply only necessary answers on upgrade

### DIFF
--- a/lib/beaker-answers/answers.rb
+++ b/lib/beaker-answers/answers.rb
@@ -4,6 +4,7 @@ module BeakerAnswers
   class Answers
 
     DEFAULT_ANSWERS =  StringifyHash.new.merge({
+      :q_install                                     => 'y',
       :q_puppet_enterpriseconsole_auth_user_email    => 'admin@example.com',
       :q_puppet_enterpriseconsole_auth_password      => '~!@#$%^*-/ aZ',
       :q_puppet_enterpriseconsole_smtp_port          => 25,
@@ -47,6 +48,12 @@ module BeakerAnswers
       BeakerAnswers.constants.select {|c| BeakerAnswers.const_get(c).is_a?(Class) && BeakerAnswers.const_get(c).respond_to?(:pe_version_matcher)}
     end
 
+    # Determine the list of supported upgrade PE versions, return as an array
+    # @return [Array<String>] An array of the supported versions
+    def self.supported_upgrade_versions
+      BeakerAnswers.constants.select {|c| BeakerAnswers.const_get(c).is_a?(Class) && BeakerAnswers.const_get(c).respond_to?(:upgrade_version_matcher)}
+    end
+
     # When given a Puppet Enterprise version, a list of hosts and other
     # qualifying data this method will return the appropriate object that can be used
     # to generate answer file data.
@@ -58,6 +65,15 @@ module BeakerAnswers
     # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
     #   data.
     def self.create version, hosts, options
+      # if :upgrade is detected, then we return the simpler upgrade answers
+      if options[:type] == :upgrade
+        self.supported_upgrade_versions.each do |upgrade_version_class|
+          if BeakerAnswers.const_get(upgrade_version_class).send(:upgrade_version_matcher) =~ version
+            return BeakerAnswers.const_get(upgrade_version_class).send(:new, version, hosts, options)
+          end
+        end
+        warn 'Only upgrades to version 3.8 and above generate specific upgrade answers. Defaulting to full answers.'
+      end
 
       # finds all potential version classes
       # discovers new version classes as they are added, no more crazy case statement

--- a/lib/beaker-answers/versions/upgrade.rb
+++ b/lib/beaker-answers/versions/upgrade.rb
@@ -1,0 +1,19 @@
+module BeakerAnswers
+  # In the case of upgrades, we lay down a much simpler file
+  class Upgrade < Answers
+
+    def self.upgrade_version_matcher
+      /\A2015\.[123]|\A2016\.[1234]/
+    end
+
+    def generate_answers
+      the_answers = {}
+      @hosts.each do |host|
+        the_answers[host.name] = {:q_install => answer_for(@options, :q_install)}
+        # merge custom host answers if available
+        the_answers[host.name] = the_answers[host.name].merge(host[:custom_answers]) if host[:custom_answers]
+      end
+      the_answers
+    end
+  end
+end

--- a/lib/beaker-answers/versions/upgrade38.rb
+++ b/lib/beaker-answers/versions/upgrade38.rb
@@ -1,0 +1,31 @@
+module BeakerAnswers
+  # In the case of upgrades, we lay down a much simpler file
+  class Upgrade38 < Upgrade
+
+    def self.upgrade_version_matcher
+      /\A3\.8/
+    end
+
+    def generate_answers
+      the_answers = super
+      the_answers.map do |hostname, answers|
+        # First check to see if there is a host option for this setting
+        # and skip to the next object if it is already defined.
+        if the_answers[hostname][:q_enable_future_parser]
+          next
+        # Check now if it was set in the global options.
+        elsif @options[:answers] && @options[:answers][:q_enable_future_parser]
+          the_answers[hostname][:q_enable_future_parser] = @options[:answers][:q_enable_future_parser]
+          next
+        # If we didn't set it on a per host or global option basis, set it to
+        # 'y' here. We could have possibly set it in the DEFAULT_ANSWERS, but it
+        # is unclear what kind of effect that might have on all the other answers
+        # that rely on it defaulting to 'n'.
+        else
+          the_answers[hostname][:q_enable_future_parser] = 'y'
+        end
+      end
+      the_answers
+    end
+  end
+end

--- a/spec/beaker-answers/beaker-answers_spec.rb
+++ b/spec/beaker-answers/beaker-answers_spec.rb
@@ -29,6 +29,35 @@ describe BeakerAnswers do
     end
   end
 
+  context 'when we are upgrading to a version > 3.8' do
+    supported_general_upgrade_versions = [ '2015.1.0',
+                                           '2016.1.0',
+                                           '2016.2.1']
+    supported_general_upgrade_versions.each do |version|
+      it "the version #{version} generates general upgrade answers" do
+        @ver = version
+        options[:type] = :upgrade
+        expect( answers ).to be_a_kind_of BeakerAnswers::Upgrade
+      end
+    end
+  end
+
+  it 'generates upgrade38 answers when type is upgrade and the version 3.8' do
+    @ver = '3.8.3'
+    options[:type] = :upgrade
+    expect( answers ).to be_a_kind_of BeakerAnswers::Upgrade38
+  end
+
+  it 'generates 2016.2 answers for 2016.2 hosts' do
+    @ver = '2016.2.0'
+    expect( answers ).to be_a_kind_of BeakerAnswers::Version20162
+  end
+
+  it 'generates 2016.1 answers for 2016.1 hosts' do
+    @ver = '2016.1.0'
+    expect( answers ).to be_a_kind_of BeakerAnswers::Version20161
+  end
+
   it 'generates 2015.3 answers for 2015.3 hosts' do
     @ver = '2015.3.0'
     expect( answers ).to be_a_kind_of BeakerAnswers::Version20153
@@ -316,6 +345,99 @@ describe BeakerAnswers::Version40 do
     hosts.each do |host|
       expect( host[:answers] ).to be === @answers[host.name]
     end
+  end
+end
+
+describe BeakerAnswers::Upgrade do
+
+  let( :options )     { StringifyHash.new }
+  let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
+  let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                  basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                  basic_hosts[2]['roles'] = ['database', 'agent']
+                  basic_hosts }
+  let( :answers )     { BeakerAnswers::Answers.create(@ver, hosts, options.merge({:type => :upgrade}) ) }
+
+  before :each do
+    @ver = '2015.3'
+    @answers = answers.answers
+  end
+
+  context 'when per host custom answers are provided for the master and dashboard' do
+    let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                    basic_hosts[0][:custom_answers] = { :q_custom0 => '0LOOK' }
+                    basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                    basic_hosts[1][:custom_answers] = { :q_custom1 => 'LOOKLOOK',
+                                                        :q_custom2 => "LOOK3"}
+                    basic_hosts[2]['roles'] = ['database', 'agent']
+                    basic_hosts }
+
+    it 'adds those custom answers to the master' do
+      expect( @answers['vm1'][:q_custom0] ).to be === '0LOOK'
+      expect( @answers['vm1'][:q_install] ).to eq('y')
+      expect( @answers['vm1'].size).to eq(2)
+    end
+
+    it 'adds custom answers to the dashboard' do
+      expect( @answers['vm2'][:q_custom1] ).to be === 'LOOKLOOK'
+      expect( @answers['vm2'][:q_custom2] ).to be === 'LOOK3'
+      expect( @answers['vm2'][:q_install] ).to eq('y')
+      expect( @answers['vm2'].size).to eq(3)
+    end
+
+    it 'does not add custom answers for the database' do
+      expect(@answers['vm3'][:q_install]).to eq('y')
+      expect(@answers['vm3'].length).to eq(1)
+    end
+  end
+
+  context 'when no custom answers are provided' do
+    it "each answer should have only one key for :q_install" do
+      @answers.each do |vmname, answer|
+        expect(answer[:q_install]).to eq('y')
+        expect(answer.length).to eq(1)
+      end
+    end
+  end
+end
+
+describe BeakerAnswers::Upgrade38 do
+
+  let( :options )     { StringifyHash.new }
+  let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
+  let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                  basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                  basic_hosts[2]['roles'] = ['database', 'agent']
+                  basic_hosts }
+  let( :answers )     { BeakerAnswers::Answers.create(@ver, hosts, options.merge({:type => :upgrade}) ) }
+
+  before :each do
+    @ver = '3.8'
+    @answers = answers.answers
+  end
+
+  context 'when no special answers are provided' do
+    it "each answer should have only two keys" do
+      @answers.each do |vmname, answer|
+        expect(answer[:q_install]).to eq('y')
+        expect(answer[:q_enable_future_parser]).to eq('y')
+        expect(answer.length).to eq(2)
+      end
+    end
+  end
+
+  context 'when we set :q_enable_future_parser in global options' do
+    let( :options ) {
+      options = StringifyHash.new
+      options[:answers] = { :q_enable_future_parser => 'thefutureparser!!!'}
+      options
+    }
+    it 'sets that parser option from the global options' do
+      @answers.each do |vmname, answer|
+        expect(answer[:q_enable_future_parser]).to eq('thefutureparser!!!')
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
Previous to this commit, answer files were generated in full during
upgrade scenarios; this does not match the user workflow or what is
documented for upgrades, so we should only supply answers needed. The
answers `create` method now checks the `:type` in options and creates a
separate branch of `Answers` named `Upgrade`.

This change only affects PE 3.8 and higher; all lower versions will
continue to produce an entire answers file.