### PR TITLE
(BKR-791) Add answer for migrate question for PE 3.8

### DIFF
--- a/lib/beaker-answers/versions/upgrade38.rb
+++ b/lib/beaker-answers/versions/upgrade38.rb
@@ -25,6 +25,24 @@ module BeakerAnswers
           the_answers[hostname][:q_enable_future_parser] = 'y'
         end
       end
+
+      the_answers.map do |hostname, answers|
+        # First check to see if there is a host option for this setting
+        # and skip to the next object if it is already defined.
+        if the_answers[hostname][:q_exit_for_nc_migrate]
+          next
+        # Check now if it was set in the global options.
+        elsif @options[:answers] && @options[:answers][:q_exit_for_nc_migrate]
+          the_answers[hostname][:q_exit_for_nc_migrate] = @options[:answers][:q_exit_for_nc_migrate]
+          next
+        # If we didn't set it on a per host or global option basis, set it to
+        # 'n' here. We could have possibly set it in the DEFAULT_ANSWERS, but it
+        # is unclear what kind of effect that might have on all the other answers
+        # that rely on it defaulting to 'n'.
+        else
+          the_answers[hostname][:q_exit_for_nc_migrate] = 'n'
+        end
+      end
       the_answers
     end
   end

--- a/spec/beaker-answers/beaker-answers_spec.rb
+++ b/spec/beaker-answers/beaker-answers_spec.rb
@@ -417,11 +417,12 @@ describe BeakerAnswers::Upgrade38 do
   end
 
   context 'when no special answers are provided' do
-    it "each answer should have only two keys" do
+    it "each answer should have only three keys" do
       @answers.each do |vmname, answer|
         expect(answer[:q_install]).to eq('y')
         expect(answer[:q_enable_future_parser]).to eq('y')
-        expect(answer.length).to eq(2)
+        expect(answer[:q_exit_for_nc_migrate]).to eq('n')
+        expect(answer.length).to eq(3)
       end
     end
   end


### PR DESCRIPTION
Upgrades from PE 3.3.x to PE 3.8 require an answer for the migration
tool; this PR adds a default answer of 'n' for that question.