### PR TITLE
(PE-14877) Pass in orchestrator db to console

### DIFF
--- a/lib/beaker-answers/versions/version20162.rb
+++ b/lib/beaker-answers/versions/version20162.rb
@@ -9,5 +9,24 @@ module BeakerAnswers
     def self.pe_version_matcher
       /\A2016\.2/
     end
+
+    def generate_answers
+      the_answers = super
+
+      return the_answers if @options[:masterless]
+      console = only_host_with_role(@hosts, 'dashboard')
+
+      # To allow SSL cert based auth in the new installer while maintaining the legacy
+      # bash script, the console node now needs to know about the orchestrator database user
+      # and name if they are specified to be non default
+      orchestrator_db = {
+        :q_orchestrator_database_name     => answer_for(@options, :q_orchestrator_database_name),
+        :q_orchestrator_database_user     => answer_for(@options, :q_orchestrator_database_user),
+      }
+
+      the_answers[console.name].merge!(orchestrator_db)
+
+      the_answers
+    end
   end
 end

--- a/spec/beaker-answers/beaker-answers_spec.rb
+++ b/spec/beaker-answers/beaker-answers_spec.rb
@@ -357,6 +357,27 @@ describe BeakerAnswers::Version20153 do
   end
 end
 
+describe BeakerAnswers::Version20162 do
+  let( :options )     { StringifyHash.new }
+  let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
+  let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                  basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                  basic_hosts[2]['roles'] = ['database', 'agent']
+                  basic_hosts }
+  let( :answers )     { BeakerAnswers::Answers.create(@ver, hosts, options) }
+  let( :upgrade_answers )     { BeakerAnswers::Answers.create(@ver, hosts, options.merge( {:type => :upgrade}) ) }
+
+  before :each do
+    @ver = '2016.2'
+    @answers = answers.answers
+  end
+
+  it 'should add orchestrator database answers to console' do
+    expect( @answers['vm2'][:q_orchestrator_database_name] ).to be === 'pe-orchestrator'
+    expect( @answers['vm2'][:q_orchestrator_database_user] ).to be === 'Orc3Str8R'
+  end
+end
+
 describe BeakerAnswers::Version32 do
   let( :options )     { StringifyHash.new }
   let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }


### PR DESCRIPTION
To allow SSL cert based auth in the new installer while maintaining the legacy
bash script, the console node now needs to know about the orchestrator database user
and name if they are specified to be non default