### PR TITLE
(BKR-763) Add upgrade answers for PE 3.8.x

### DIFF
--- a/lib/beaker-answers/versions/upgrade.rb
+++ b/lib/beaker-answers/versions/upgrade.rb
@@ -1,0 +1,18 @@
+module BeakerAnswers
+  # In the case of upgrades, we only start with the answer for installation
+  class Upgrade < Answers
+
+    def default_upgrade_answers
+      {:q_install => answer_for(@options, :q_install)}
+    end
+
+    def generate_answers
+      the_answers = {}
+      @hosts.each do |host|
+        the_answers[host.name] = default_upgrade_answers
+      end
+      the_answers
+    end
+
+  end
+end

--- a/lib/beaker-answers/versions/upgrade38.rb
+++ b/lib/beaker-answers/versions/upgrade38.rb
@@ -1,0 +1,79 @@
+module BeakerAnswers
+  # In the case of upgrades, we lay down only necessary answers
+  class Upgrade38 < Upgrade
+
+    def self.upgrade_version_matcher
+      /\A3\.8/
+    end
+
+    def generate_answers
+      the_answers = super
+      dashboard = only_host_with_role(@hosts, 'dashboard')
+      master = only_host_with_role(@hosts, 'master')
+      database = only_host_with_role(@hosts, 'database')
+      @hosts.each do |host|
+        # Both the dashboard and database need shared answers about the new console services
+        if host == dashboard || host == database
+          the_answers[host.name][:q_rbac_database_name] = answer_for(@options, :q_rbac_database_name)
+          the_answers[host.name][:q_rbac_database_user] = answer_for(@options, :q_rbac_database_user)
+          the_answers[host.name][:q_rbac_database_password] = "'#{answer_for(@options, :q_rbac_database_password)}'"
+          the_answers[host.name][:q_activity_database_name] = answer_for(@options, :q_activity_database_name)
+          the_answers[host.name][:q_activity_database_user] = answer_for(@options, :q_activity_database_user)
+          the_answers[host.name][:q_activity_database_password] = "'#{answer_for(@options, :q_activity_database_password)}'"
+          the_answers[host.name][:q_classifier_database_name] = answer_for(@options, :q_database_name)
+          the_answers[host.name][:q_classifier_database_user] = answer_for(@options, :q_classifier_database_user)
+          the_answers[host.name][:q_classifier_database_password] = "'#{answer_for(@options, :q_classifier_database_password)}'"
+          the_answers[host.name][:q_puppetmaster_certname] = answer_for(@options, :q_puppetmaster_certname)
+          # The dashboard also needs additional answers about puppetdb on the remote host
+          if host == dashboard
+            the_answers[host.name][:q_puppet_enterpriseconsole_auth_password] = "'#{answer_for(@options, :q_puppet_enterpriseconsole_auth_password)}'"
+            the_answers[host.name][:q_puppetdb_hostname] = answer_for(@options, :q_puppetdb_hostname, database.reachable_name)
+            the_answers[host.name][:q_puppetdb_database_password] = answer_for(@options, :q_puppetdb_database_password)
+            the_answers[host.name][:q_puppetdb_database_name] = answer_for(@options, :q_puppetdb_database_name)
+            the_answers[host.name][:q_puppetdb_database_user] = answer_for(@options, :q_puppetdb_database_user)
+            the_answers[host.name][:q_puppetdb_port] = answer_for(@options, :q_puppetdb_port)
+          end
+        end
+        # merge custom host answers if available
+        the_answers[host.name] = the_answers[host.name].merge(host[:custom_answers]) if host[:custom_answers]
+      end
+
+      the_answers.map do |hostname, answers|
+        # First check to see if there is a host option for this setting
+        # and skip to the next object if it is already defined.
+        if the_answers[hostname][:q_enable_future_parser]
+          next
+        # Check now if it was set in the global options.
+        elsif @options[:answers] && @options[:answers][:q_enable_future_parser]
+          the_answers[hostname][:q_enable_future_parser] = @options[:answers][:q_enable_future_parser]
+          next
+        # If we didn't set it on a per host or global option basis, set it to
+        # 'y' here. We could have possibly set it in the DEFAULT_ANSWERS, but it
+        # is unclear what kind of effect that might have on all the other answers
+        # that rely on it defaulting to 'n'.
+        else
+          the_answers[hostname][:q_enable_future_parser] = 'y'
+        end
+      end
+
+      the_answers.map do |hostname, answers|
+        # First check to see if there is a host option for this setting
+        # and skip to the next object if it is already defined.
+        if the_answers[hostname][:q_exit_for_nc_migrate]
+          next
+        # Check now if it was set in the global options.
+        elsif @options[:answers] && @options[:answers][:q_exit_for_nc_migrate]
+          the_answers[hostname][:q_exit_for_nc_migrate] = @options[:answers][:q_exit_for_nc_migrate]
+          next
+        # If we didn't set it on a per host or global option basis, set it to
+        # 'n' here. We could have possibly set it in the DEFAULT_ANSWERS, but it
+        # is unclear what kind of effect that might have on all the other answers
+        # that rely on it defaulting to 'n'.
+        else
+          the_answers[hostname][:q_exit_for_nc_migrate] = 'n'
+        end
+      end
+      the_answers
+    end
+  end
+end

--- a/lib/beaker-answers/versions/version30.rb
+++ b/lib/beaker-answers/versions/version30.rb
@@ -73,7 +73,7 @@ module BeakerAnswers
         console_auth_password = "'#{answer_for(options, :q_puppet_enterpriseconsole_auth_password)}'"
         puppetdb_database_name = answer_for(options, :q_puppetdb_database_name, 'pe-puppetdb')
         puppetdb_database_user = answer_for(options, :q_puppetdb_database_user, 'mYpdBu3r')
-        puppetdb_database_password = answer_for(options, :q_puppetdb_database_password, "'#{answer_for(options, :q_puppetdb_password)}'")
+        puppetdb_database_password = answer_for(options, :q_puppetdb_database_password)
         console_auth_database_name = answer_for(options, :q_puppet_enterpriseconsole_auth_database_name, 'console_auth')
         console_auth_database_user = answer_for(options, :q_puppet_enterpriseconsole_auth_database_user, 'mYu7hu3r')
         console_auth_database_password = answer_for(options, :q_puppet_enterpriseconsole_auth_database_password, console_auth_password)

--- a/spec/beaker-answers/beaker-answers_spec.rb
+++ b/spec/beaker-answers/beaker-answers_spec.rb
@@ -29,6 +29,36 @@ describe BeakerAnswers do
     end
   end
 
+  context 'when we are upgrading to a version > 3.8' do
+    supported_general_upgrade_versions = [ '2015.1.0',
+                                           '2016.1.0',
+                                           '2016.2.1']
+    supported_general_upgrade_versions.each do |version|
+      it "still creates the full install answers" do
+        @ver = version
+        options[:type] = :upgrade
+        expect( answers ).to be_a_kind_of BeakerAnswers::Answers
+        expect( answers ).to_not be_a_kind_of BeakerAnswers::Upgrade
+      end
+    end
+  end
+
+  it 'generates upgrade38 answers when type is upgrade and the version 3.8' do
+    @ver = '3.8.3'
+    options[:type] = :upgrade
+    expect( answers ).to be_a_kind_of BeakerAnswers::Upgrade38
+  end
+
+  it 'generates 2016.2 answers for 2016.2 hosts' do
+    @ver = '2016.2.0'
+    expect( answers ).to be_a_kind_of BeakerAnswers::Version20162
+  end
+
+  it 'generates 2016.1 answers for 2016.1 hosts' do
+    @ver = '2016.1.0'
+    expect( answers ).to be_a_kind_of BeakerAnswers::Version20161
+  end
+
   it 'generates 2015.3 answers for 2015.3 hosts' do
     @ver = '2015.3.0'
     expect( answers ).to be_a_kind_of BeakerAnswers::Version20153

--- a/spec/beaker-answers/upgrade_spec.rb
+++ b/spec/beaker-answers/upgrade_spec.rb
@@ -1,0 +1,137 @@
+describe BeakerAnswers::Upgrade do
+  let( :options )     { StringifyHash.new }
+  let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
+  let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                  basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                  basic_hosts[2]['roles'] = ['database', 'agent']
+                  basic_hosts }
+  let( :answers )     { BeakerAnswers::Upgrade.new(@ver, hosts, options.merge({:type => :upgrade}) ) }
+
+  before :each do
+    @ver = '3.8'
+    @answers = answers.answers
+  end
+
+  context '#generate_answers' do
+    it 'only adds the default yes for each host' do
+      host_answers = answers.generate_answers
+      host_answers.each do |host, host_answer|
+        expect(host_answer).to eq({:q_install => 'y'})
+        expect(host_answer.length).to eq(1)
+      end
+    end
+  end
+
+end
+
+describe BeakerAnswers::Upgrade38 do
+
+  let( :options )     { StringifyHash.new }
+  let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
+  let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                  basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                  basic_hosts[2]['roles'] = ['database', 'agent']
+                  basic_hosts }
+  let( :answers )     { BeakerAnswers::Answers.create(@ver, hosts, options.merge({:type => :upgrade}) ) }
+
+  before :each do
+    @ver = '3.8'
+    @answers = answers.answers
+  end
+
+  context 'when no special answers are provided' do
+    it "the master should have only three keys" do
+      answer = @answers['vm1']
+      expect(answer[:q_install]).to eq('y')
+      expect(answer[:q_enable_future_parser]).to eq('y')
+      expect(answer[:q_exit_for_nc_migrate]).to eq('n')
+      expect(answer.length).to eq(3)
+    end
+
+    it 'the dashboard should have 19 keys provided' do
+      answer = @answers['vm2']
+
+      expect(answer[:q_install]).to eq('y')
+      expect(answer[:q_enable_future_parser]).to eq('y')
+      expect(answer[:q_exit_for_nc_migrate]).to eq('n')
+      expect(answer[:q_rbac_database_name]).to eq(answers.answer_for(options, :q_rbac_database_name))
+      expect(answer[:q_rbac_database_user]).to eq(answers.answer_for(options, :q_rbac_database_user))
+      expect(answer[:q_rbac_database_password]).to eq("'#{(answers.answer_for(options, :q_rbac_database_password))}'")
+      expect(answer[:q_activity_database_user]).to eq(answers.answer_for(options, :q_activity_database_user))
+      expect(answer[:q_activity_database_name]).to eq(answers.answer_for(options, :q_activity_database_name))
+      expect(answer[:q_activity_database_password]).to eq("'#{(answers.answer_for(options, :q_activity_database_password))}'")
+      expect(answer[:q_classifier_database_name]).to eq(answers.answer_for(options, :q_database_name))
+      expect(answer[:q_classifier_database_user]).to eq(answers.answer_for(options, :q_classifier_database_user))
+      expect(answer[:q_classifier_database_password]).to eq("'#{(answers.answer_for(options, :q_classifier_database_password))}'")
+      expect(answer[:q_puppetdb_database_name]).to eq(answers.answer_for(options, :q_puppetdb_database_name))
+      expect(answer[:q_puppetdb_database_user]).to eq(answers.answer_for(options, :q_puppetdb_database_user))
+      expect(answer[:q_puppetdb_database_password]).to eq(answers.answer_for(options, :q_puppetdb_database_password))
+      expect(answer[:q_puppet_enterpriseconsole_auth_password]).to eq("'#{(answers.answer_for(options, :q_puppet_enterpriseconsole_auth_password))}'")
+      expect(answer[:q_puppetdb_port]).to eq(answers.answer_for(options, :q_puppetdb_port))
+      expect(answer[:q_install]).to eq('y')
+      expect(answer[:q_enable_future_parser]).to eq('y')
+      expect(answer[:q_exit_for_nc_migrate]).to eq('n')
+      expect(answer.length).to eq(19)
+    end
+ 
+    it 'the database should have 13 keys provided' do
+      answer = @answers['vm3']
+
+      expect(answer[:q_install]).to eq('y')
+      expect(answer[:q_enable_future_parser]).to eq('y')
+      expect(answer[:q_exit_for_nc_migrate]).to eq('n')
+      expect(answer[:q_rbac_database_name]).to eq(answers.answer_for(options, :q_rbac_database_name))
+      expect(answer[:q_rbac_database_user]).to eq(answers.answer_for(options, :q_rbac_database_user))
+      expect(answer[:q_rbac_database_password]).to eq("'#{(answers.answer_for(options, :q_rbac_database_password))}'")
+      expect(answer[:q_activity_database_user]).to eq(answers.answer_for(options, :q_activity_database_user))
+      expect(answer[:q_activity_database_name]).to eq(answers.answer_for(options, :q_activity_database_name))
+      expect(answer[:q_activity_database_password]).to eq("'#{(answers.answer_for(options, :q_activity_database_password))}'")
+      expect(answer[:q_classifier_database_name]).to eq(answers.answer_for(options, :q_database_name))
+      expect(answer[:q_classifier_database_user]).to eq(answers.answer_for(options, :q_classifier_database_user))
+      expect(answer[:q_classifier_database_password]).to eq("'#{(answers.answer_for(options, :q_classifier_database_password))}'")
+      expect(answer[:q_install]).to eq('y')
+      expect(answer[:q_enable_future_parser]).to eq('y')
+      expect(answer[:q_exit_for_nc_migrate]).to eq('n')
+      expect(answer.length).to eq(13)
+    end
+  end
+
+  context 'when we set :q_enable_future_parser in global options' do
+    let( :options ) {
+      options = StringifyHash.new
+      options[:answers] = { :q_enable_future_parser => 'thefutureparser!!!'}
+      options
+    }
+    it 'sets that parser option from the global options' do
+      @answers.each do |vmname, answer|
+        expect(answer[:q_enable_future_parser]).to eq('thefutureparser!!!')
+      end
+    end
+
+  context 'when per host custom answers are provided for the master and dashboard' do
+    let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                    basic_hosts[0][:custom_answers] = { :q_custom0 => '0LOOK' }
+                    basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                    basic_hosts[1][:custom_answers] = { :q_custom1 => 'LOOKLOOK',
+                                                        :q_custom2 => "LOOK3"}
+                    basic_hosts[2]['roles'] = ['database', 'agent']
+                    basic_hosts }
+
+    it 'adds those custom answers to the master' do
+      expect( @answers['vm1'][:q_custom0] ).to be === '0LOOK'
+      expect(@answers['vm1'].length).to eq(4)
+    end
+
+    it 'adds custom answers to the dashboard' do
+      expect( @answers['vm2'][:q_custom1] ).to be === 'LOOKLOOK'
+      expect( @answers['vm2'][:q_custom2] ).to be === 'LOOK3'
+      expect( @answers['vm2'].length).to eq(21)
+    end
+
+    it 'does not add custom answers for the database' do
+      expect(@answers['vm3'].length).to eq(13)
+    end
+  end
+
+  end
+end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -82,6 +82,7 @@ module HostHelpers
 
     host = make_opts.merge(host_hash)
 
+    allow(host).to receive( :reachable_name ).and_return( name )
     allow(host).to receive( :name ).and_return( name )
     allow(host).to receive( :to_s ).and_return( name )
     allow(host).to receive( :exec ).and_return( generate_result( name, host_hash ) )


### PR DESCRIPTION
This PR specifically targets answers for upgrading to PE 3.8.x. It adds
a new subclassed branch directly from `Answers` and looks for the
`options[:type][:upgrade]` option from beaker. All other upgrade types
will continue to create full answer sets.