### PR TITLE
(PE-16028) Update required answers for 2016.2

### DIFF
--- a/lib/beaker-answers/versions/version20162.rb
+++ b/lib/beaker-answers/versions/version20162.rb
@@ -76,13 +76,14 @@ module BeakerAnswers
       puppetdb = only_host_with_role(@hosts, 'database')
       console = only_host_with_role(@hosts, 'dashboard')
 
-      config["#{ns}::certificate_authority_host"] = answer_for(@options, "#{ns}::certificate_authority_host", master.hostname)
       config["#{ns}::puppet_master_host"] = answer_for(@options, "#{ns}::puppet_master_host", master.hostname)
-      config["#{ns}::console_host"] = answer_for(@options, "#{ns}::console_host", console.hostname)
-      config["#{ns}::puppetdb_host"] = answer_for(@options, "#{ns}::puppetdb_host", puppetdb.hostname)
-      config["#{ns}::database_host"] = answer_for(@options, "#{ns}::database_host", puppetdb.hostname)
-      config["#{ns}::pcp_broker_host"] = answer_for(@options, "#{ns}::pcp_broker_host", master.hostname)
-      config["#{ns}::mcollective_middleware_hosts"] = [answer_for(@options, "#{ns}::mcollective_middleware_hosts", master.hostname)]
+
+      # Monolithic installs now only require the puppet_master_host, so only pass in the console
+      # and puppetdb host if it is a split install
+      if [master, puppetdb, console].uniq.length != 1
+        config["#{ns}::console_host"] = answer_for(@options, "#{ns}::console_host", console.hostname)
+        config["#{ns}::puppetdb_host"] = answer_for(@options, "#{ns}::puppetdb_host", puppetdb.hostname)
+      end
 
       return config
     end


### PR DESCRIPTION
Previous to this commit, answer generation for 2016.2 would generate a
list of parameters on the puppet_enterprise for both mono and split. Due
to changes introduced in Puppet 4.4, the puppet_enterprsie module no
longer needs all host parameters in a monolithic install case.
This commit updates the generation to match what the module has changed
to use. For a monolithic install, the only required answers are now the
console admin password, and puppet_master_host. for split installs with
PE postgres, just master, console and puppetdb host.