### PR TITLE
(ENTERPRISE-910) Unpin hocon

### DIFF
--- a/beaker-answers.gemspec
+++ b/beaker-answers.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'require_all', '~> 1.3.2'
-  s.add_runtime_dependency 'hocon', '~> 0.9.5'
+  s.add_runtime_dependency 'hocon', '~> 1.0'
 
 end


### PR DESCRIPTION
hocon < 1 is not compatible with infraspec 2.59.1.  This push it to ~1.0
to match beaker declaration and have infraspec working again.