### PR TITLE
(PE-16065) Do not fall back to ip address when setting puppetdb hostname

### DIFF
--- a/lib/beaker-answers/versions/upgrade38.rb
+++ b/lib/beaker-answers/versions/upgrade38.rb
@@ -27,7 +27,7 @@ module BeakerAnswers
           # The dashboard also needs additional answers about puppetdb on the remote host
           if host == dashboard
             the_answers[host.name][:q_puppet_enterpriseconsole_auth_password] = "'#{answer_for(@options, :q_puppet_enterpriseconsole_auth_password)}'"
-            the_answers[host.name][:q_puppetdb_hostname] = answer_for(@options, :q_puppetdb_hostname, database.reachable_name)
+            the_answers[host.name][:q_puppetdb_hostname] = answer_for(@options, :q_puppetdb_hostname)
             the_answers[host.name][:q_puppetdb_database_password] = "'#{answer_for(@options, :q_puppetdb_database_password)}'"
             the_answers[host.name][:q_puppetdb_database_name] = answer_for(@options, :q_puppetdb_database_name)
             the_answers[host.name][:q_puppetdb_database_user] = answer_for(@options, :q_puppetdb_database_user)


### PR DESCRIPTION
Before this commit the puppetdb hostname answer would fallback to being
an ip address which would cause the installer to do incorrect things as
we depend on those answers to be hostnames for certificate generation
and configuration bootstrap purposes.

This commit changes the q_puppetdb_hostname answer to be the hostname of
the puppetdb node instead of its ip address which is returned by the
reachable_name method on the host object.