### PR TITLE
(PE-16772) Remove app_orch from 20163x answers

### DIFF
--- a/lib/beaker-answers/versions/version20163.rb
+++ b/lib/beaker-answers/versions/version20163.rb
@@ -12,6 +12,11 @@ module BeakerAnswers
 
     def generate_answers
       the_answers = super
+
+      # use_application_services is deprecated
+      the_answers.delete('puppet_enterprise::use_application_services')
+
+      the_answers
     end
   end
 end

--- a/spec/beaker-answers/versions/version20163_spec.rb
+++ b/spec/beaker-answers/versions/version20163_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'json'
+
+describe BeakerAnswers::Version20163 do
+  let( :ver )         { '2016.3.0' }
+  let( :options )     { StringifyHash.new }
+  let( :basic_hosts ) { make_hosts( {'pe_ver' => ver } ) }
+  let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                  basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                  basic_hosts[2]['roles'] = ['database', 'agent']
+                  basic_hosts }
+  let( :answers )     { BeakerAnswers::Answers.create(ver, hosts, options) }
+  let( :answer_hash ) { answers.answers }
+
+  context 'when generating a hiera config' do
+    context 'for a monolithic install' do
+      let( :basic_hosts ) { make_hosts( {'pe_ver' => ver }, 1 ) }
+      let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent', 'dashboard', 'database']
+                      basic_hosts }
+      let( :gold_role_answers ) do
+        {
+          "console_admin_password" => default_password,
+          "puppet_enterprise::puppet_master_host" => basic_hosts[0].hostname,
+        }
+      end
+
+      include_examples 'pe.conf'
+    end
+
+    context 'for a split install' do
+      let( :gold_role_answers ) do
+        {
+          "console_admin_password" => default_password,
+          "puppet_enterprise::puppet_master_host" => basic_hosts[0].hostname,
+          "puppet_enterprise::console_host" => basic_hosts[1].hostname,
+          "puppet_enterprise::puppetdb_host" => basic_hosts[2].hostname,
+        }
+      end
+
+      include_examples 'pe.conf'
+    end
+  end
+end


### PR DESCRIPTION
`puppet_enterprise::use_application_services` is deprecated in 2016.3.x,
so we should no longer specify it.