### PR TITLE
(PE-18282) Add agent_platforms array to 2017.1 answer files

### DIFF
--- a/lib/beaker-answers/versions/version20171.rb
+++ b/lib/beaker-answers/versions/version20171.rb
@@ -69,10 +69,16 @@ module BeakerAnswers
         "monolithic" :
         "split"
 
+      # Collect a uniq array of all host platforms modified to pe_repo class format
+      platforms = @hosts.map do |h|
+        h['platform'].gsub(/-/, '_').gsub(/\./,'')
+      end.uniq
+
       hosts_by_component.reduce(pe_conf) do |conf,entry|
         component, hosts = entry
         if !hosts.empty?
           conf["node_roles"]["pe_role::#{architecture}::#{component}"] = hosts
+          conf["agent_platforms"] = platforms
         end
         conf
       end

--- a/spec/beaker-answers/versions/version20171_spec.rb
+++ b/spec/beaker-answers/versions/version20171_spec.rb
@@ -6,8 +6,11 @@ describe BeakerAnswers::Version20171 do
   let( :options )     { StringifyHash.new }
   let( :basic_hosts ) { make_hosts( {'pe_ver' => ver } ) }
   let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                  basic_hosts[0]['platform'] = 'el-6-x86_64'
                   basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                  basic_hosts[1]['platform'] = 'el-6-x86_64'
                   basic_hosts[2]['roles'] = ['database', 'agent']
+                  basic_hosts[2]['platform'] = 'ubuntu-14.04-amd64'
                   basic_hosts }
   let( :answers )     { BeakerAnswers::Answers.create(ver, hosts, options) }
   let( :answer_hash ) { answers.answers }
@@ -16,13 +19,15 @@ describe BeakerAnswers::Version20171 do
     context 'for a monolithic install' do
       let( :basic_hosts ) { make_hosts( {'pe_ver' => ver }, 1 ) }
       let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent', 'dashboard', 'database']
+                      basic_hosts[0]['platform'] = 'el-7-x86_64'
                       basic_hosts }
       let( :gold_role_answers ) do
         {
           "console_admin_password" => default_password,
           "node_roles" => {
             "pe_role::monolithic::primary_master" => [basic_hosts[0].hostname],
-          }
+          },
+          "agent_platforms" => match_array(['el_7_x86_64'])
         }
       end
 
@@ -40,7 +45,8 @@ describe BeakerAnswers::Version20171 do
             "pe_role::split::primary_master" => [basic_hosts[0].hostname],
             "pe_role::split::console" => [basic_hosts[1].hostname],
             "pe_role::split::puppetdb" => [basic_hosts[2].hostname],
-          }
+          },
+          "agent_platforms" => match_array(['el_6_x86_64', 'ubuntu_1404_amd64'])
         }
       end
 

--- a/spec/shared/context.rb
+++ b/spec/shared/context.rb
@@ -57,7 +57,7 @@ RSpec.shared_examples 'pe.conf' do
   end
 
   it 'has just the role and values for default install' do
-    expect(answer_hash).to eq(
+    expect(answer_hash).to match(
       gold_role_answers
     )
   end
@@ -72,12 +72,12 @@ RSpec.shared_examples 'pe.conf' do
       end
 
       it 'has only the role values' do
-        expect(answer_hash).to eq(gold_role_answers)
+        expect(answer_hash).to match(gold_role_answers)
       end
 
       it 'also includes any explicitly added database parameters' do
         options.merge!(:answers => overridden_database_parameters)
-        expect(answer_hash).to eq(
+        expect(answer_hash).to match(
           gold_role_answers
             .merge(overridden_database_parameters)
         )
@@ -93,7 +93,7 @@ RSpec.shared_examples 'pe.conf' do
       end
 
       it 'has the role values and database defaults' do
-        expect(answer_hash).to eq(
+        expect(answer_hash).to match(
           gold_role_answers
             .merge(gold_db_answers)
         )
@@ -101,7 +101,7 @@ RSpec.shared_examples 'pe.conf' do
 
       it 'overrides defaults with explicitly added database parameters' do
         options.merge!(:answers => overridden_database_parameters)
-        expect(answer_hash).to eq(
+        expect(answer_hash).to match(
           gold_role_answers
             .merge(overridden_database_parameters)
         )
@@ -144,7 +144,7 @@ RSpec.shared_examples 'pe.conf' do
     end
 
     it 'matches expected answers' do
-      expect(answer_hash).to eq(gold_answers_with_overrides)
+      expect(answer_hash).to match(gold_answers_with_overrides)
     end
   end
 
@@ -163,7 +163,7 @@ RSpec.shared_examples 'pe.conf' do
     end
 
     it 'matches expected answers' do
-      expect(answer_hash).to eq(gold_answers_with_overrides)
+      expect(answer_hash).to match(gold_answers_with_overrides)
     end
   end
 end


### PR DESCRIPTION
This provides the list of agent platform classes based on all host
platform settings. As of 2017.1 this is set in pe.conf.