### PR TITLE
(PE-19203,PE-16706) Revert meep classification from Flanders

### DIFF
--- a/lib/beaker-answers.rb
+++ b/lib/beaker-answers.rb
@@ -4,6 +4,7 @@ module BeakerAnswers
   require 'beaker-answers/helpers'
   require 'beaker-answers/answers'
   require 'beaker-answers/version'
+  require 'beaker-answers/pe_conf'
   require 'json'
   require 'hocon'
   require 'hocon/config_value_factory'

--- a/lib/beaker-answers/pe_conf.rb
+++ b/lib/beaker-answers/pe_conf.rb
@@ -1,0 +1,162 @@
+module BeakerAnswers
+  # Used to generate a Hash of configuration appropriate for generating
+  # the initial MEEP pe.conf for a given set of hosts and a particular
+  # MEEP pe.conf schema version.
+  class PeConf
+
+    # The default pe.conf schema version.
+    DEFAULT_VERSION = '1.0'.freeze
+
+    # This lists various aliases for different PE components that might
+    # be installed on a host.
+    #
+    # The first entry in the list is the canonical name for the
+    # component from the PuppetX::Puppetlabs::Meep::Config.pe_components()
+    # from the pe_infrastructure module.
+    #
+    # Secondary aliases are the various working names that have been used
+    # with beaker in CI to establish that a host has that component
+    # installed on it.
+    COMPONENTS = [
+      ["primary_master", "master"],
+      ["primary_master_replica"],
+      # the 'database' alias will be troublesome if/when we begin
+      # breaking out a managed database (as opposed to external)
+      # in future PE layouts.
+      ["puppetdb", "database"],
+      ["console", "classifier", "dashboard"],
+      ["compile_master"],
+      ["mco_hub", "hub"],
+      ["mco_broker", "spoke"],
+    ]
+
+    attr_accessor :hosts, :meep_schema_version, :options
+
+    # The array of Beaker hosts are inspected to provide configuration
+    # for master, database, console nodes, and other configuration data
+    # as required by the particular pe.conf version.
+    #
+    # @param hosts [Array<Beaker::Host>]
+    # @param meep_schema_version [String] Determines the implementation which
+    #   will be used to generate pe.conf data. Defaults to '1.0'
+    # @param options [Hash] of additional option parameters. Used to supply
+    #   specific master, puppetdb, console hosts for the 1.0 implementation.
+    #   (Optional)
+    def initialize(hosts, meep_schema_version, options = {})
+      self.hosts = hosts
+      self.meep_schema_version = meep_schema_version || DEFAULT_VERSION
+      self.options = options || {}
+    end
+
+    # @return [Hash] of pe.conf configuration data
+    # @raise RuntimeError if no implementation can be found for the
+    #   meep_schema_version.
+    def configuration_hash
+      case meep_schema_version
+      when '1.0'
+        _generate_1_0_data
+      when '2.0'
+        _generate_2_0_data
+      else raise(RuntimeError, "Unknown how to produce pe.conf data for meep_schema_version: '#{meep_schema_version}'")
+      end
+    end
+
+    private
+
+    # Relies on a :master, :puppetdb and :console host having been passed
+    # in the options.
+    def _generate_1_0_data
+      pe_conf = {}
+      ns = "puppet_enterprise"
+
+      master = the_host_with_role('master')
+      puppetdb = the_host_with_role('database')
+      console = the_host_with_role('dashboard')
+
+      pe_conf["#{ns}::puppet_master_host"] = master.hostname
+
+      # Monolithic installs now only require the puppet_master_host, so only
+      # pass in the console and puppetdb host if it is a split install
+      if [master, puppetdb, console].uniq.length != 1
+        pe_conf["#{ns}::console_host"] = console.hostname
+        pe_conf["#{ns}::puppetdb_host"] = puppetdb.hostname
+      end
+
+      pe_conf
+    end
+
+    def _generate_2_0_data
+      pe_conf = {
+        "node_roles" => {}
+      }
+      hosts_by_component = {}
+
+      COMPONENTS.each do |aliases|
+        meep_component_name = aliases.first
+        # Only generate node_role settings for installing primary nodes
+        # Secondary infrastructure will be added dynamically later
+        next unless ['primary_master', 'puppetdb', 'console'].include?(meep_component_name)
+        hosts_by_component[meep_component_name] = all_hostnames_with_component(aliases)
+      end
+
+      # Reject console and puppetdb lists if they are the same as master
+      hosts_by_component.reject! do |component,hosts|
+        ["puppetdb", "console"].include?(component) &&
+          hosts_by_component["primary_master"].sort == hosts.sort
+      end
+
+      # Which is also sufficient to determine our architecture at the moment
+      architecture = (hosts_by_component.keys & ["puppetdb", "console"]).empty? ?
+        "monolithic" :
+        "split"
+
+      # Set the node_roles
+      hosts_by_component.reduce(pe_conf) do |conf,entry|
+        component, hosts = entry
+        if !hosts.empty?
+          conf["node_roles"]["pe_role::#{architecture}::#{component}"] = hosts
+        end
+        conf
+      end
+
+      # Collect a uniq array of all host platforms modified to pe_repo class format
+      platforms = hosts.map do |h|
+        h['platform'].gsub(/-/, '_').gsub(/\./,'')
+      end.uniq
+      pe_conf["agent_platforms"] = platforms
+
+      pe_conf["meep_schema_version"] = "2.0"
+
+      pe_conf
+    end
+
+    # @param host_role_aliases [Array<String>] list of strings to search for in
+    #   each host's role array
+    # @return [Array<String>] of hostnames from @hosts that include at least
+    #   one of the passed aliases
+    def all_hostnames_with_component(host_role_aliases)
+      found_hosts = hosts.select do |h|
+        !(Array(h['roles']) & host_role_aliases).empty?
+      end
+      found_hosts.map { |h| h.hostname }
+    end
+
+    # Find a single host with the role provided.  Raise an error if more than
+    # one host is found to have the provided role.
+    #
+    # @param [String] role The host returned will have this role in its role list
+    # @return [Host] The single host with the desired role in its roles list
+    # @raise [ArgumentError] Raised if more than one host has the given role
+    #   defined, or if no host has the role defined.
+    def the_host_with_role(role)
+      found_hosts = hosts.select do |h|
+        Array(h['roles']).include?(role.to_s)
+      end
+
+      if found_hosts.length == 0 or found_hosts.length > 1
+        raise ArgumentError, "There should be one host with #{role} defined, found #{found_hosts.length} matching hosts (#{found_hosts})"
+      end
+      found_hosts.first
+    end
+  end
+end

--- a/lib/beaker-answers/versions/version20162.rb
+++ b/lib/beaker-answers/versions/version20162.rb
@@ -62,23 +62,8 @@ module BeakerAnswers
     end
 
     def hiera_host_config
-      config = {}
-      ns = "puppet_enterprise"
-
-      master = only_host_with_role(@hosts, 'master')
-      puppetdb = only_host_with_role(@hosts, 'database')
-      console = only_host_with_role(@hosts, 'dashboard')
-
-      config["#{ns}::puppet_master_host"] = answer_for(@options, "#{ns}::puppet_master_host", master.hostname)
-
-      # Monolithic installs now only require the puppet_master_host, so only pass in the console
-      # and puppetdb host if it is a split install
-      if [master, puppetdb, console].uniq.length != 1
-        config["#{ns}::console_host"] = answer_for(@options, "#{ns}::console_host", console.hostname)
-        config["#{ns}::puppetdb_host"] = answer_for(@options, "#{ns}::puppetdb_host", puppetdb.hostname)
-      end
-
-      return config
+      pe_conf = BeakerAnswers::PeConf.new(@hosts, '1.0')
+      pe_conf.configuration_hash
     end
 
     def hiera_db_config

--- a/lib/beaker-answers/versions/version20171.rb
+++ b/lib/beaker-answers/versions/version20171.rb
@@ -10,74 +10,12 @@ module BeakerAnswers
       /\A2017\.1/
     end
 
-    # This lists various aliases for different PE components that might
-    # be installed on a host.
-    #
-    # The first entry in the list is the canonical name for the
-    # component from the PuppetX::Puppetlabs::Meep::Config.pe_components()
-    # from the pe_infrastructure module.
-    #
-    # Secondary aliases are the various working names that have been used
-    # with beaker in CI to establish that a host has that component
-    # installed on it.
-    COMPONENTS = [
-      ["primary_master", "master"],
-      ["primary_master_replica"],
-      # the 'database' alias will be troublesome if/when we begin
-      # breaking out a managed database (as opposed to external)
-      # in future PE layouts.
-      ["puppetdb", "database"],
-      ["console", "classifier", "dashboard"],
-      ["compile_master"],
-      ["mco_hub", "hub"],
-      ["mco_broker", "spoke"],
-    ]
-
-    # @param host_role_aliases [Array<String>] list of strings to search for in
-    #   each host's role array
-    # @return [Array<String>] of hostnames from @hosts that include at least
-    #   one of the passed aliases
-    def all_hosts_with_component(host_role_aliases)
-      hosts = @hosts.select do |h|
-        !(Array(h['roles']) & host_role_aliases).empty?
-      end
-      hosts.map { |h| h.hostname }
-    end
-
     # This used to generate the profile host parameters, but now generates a MEEP
     # 2.0 node_roles hash mapping roles -> node certs based on the same host and
     # role information.
     def hiera_host_config
-      pe_conf = {
-        "node_roles" => {}
-      }
-      hosts_by_component = {}
-
-      COMPONENTS.each do |aliases|
-        meep_component_name = aliases.first
-        hosts_by_component[meep_component_name] = all_hosts_with_component(aliases)
-      end
-
-      # Reject console and puppetdb lists if they are the same as master
-      hosts_by_component.reject! do |component,hosts|
-        ["puppetdb", "console"].include?(component) &&
-          hosts_by_component["primary_master"].sort == hosts.sort
-      end
-
-      # Which is also sufficient to determine our architecture at the moment
-      architecture = (hosts_by_component.keys & ["puppetdb", "console"]).empty? ?
-        "monolithic" :
-        "split"
-
-      hosts_by_component.reduce(pe_conf) do |conf,entry|
-        component, hosts = entry
-        if !hosts.empty?
-          conf["node_roles"]["pe_role::#{architecture}::#{component}"] = hosts
-        end
-        conf
-      end
-
-      pe_conf
+      pe_conf = BeakerAnswers::PeConf.new(@hosts, @options[:meep_schema_version])
+      pe_conf.configuration_hash
     end
   end
 end

--- a/lib/beaker-answers/versions/version20171.rb
+++ b/lib/beaker-answers/versions/version20171.rb
@@ -10,12 +10,5 @@ module BeakerAnswers
       /\A2017\.1/
     end
 
-    # This used to generate the profile host parameters, but now generates a MEEP
-    # 2.0 node_roles hash mapping roles -> node certs based on the same host and
-    # role information.
-    def hiera_host_config
-      pe_conf = BeakerAnswers::PeConf.new(@hosts, @options[:meep_schema_version])
-      pe_conf.configuration_hash
-    end
   end
 end

--- a/lib/beaker-answers/versions/version20172.rb
+++ b/lib/beaker-answers/versions/version20172.rb
@@ -9,5 +9,13 @@ module BeakerAnswers
     def self.pe_version_matcher
       /\A2017\.2/
     end
+
+    # This is used to generate the profile host parameters, but now passes the
+    # options[:meep_schema_version] to determine which form of pe.conf is to be
+    # generated.
+    def hiera_host_config
+      pe_conf = BeakerAnswers::PeConf.new(@hosts, @options[:meep_schema_version])
+      pe_conf.configuration_hash
+    end
   end
 end

--- a/lib/beaker-answers/versions/version20172.rb
+++ b/lib/beaker-answers/versions/version20172.rb
@@ -1,0 +1,13 @@
+require 'beaker-answers/versions/version20171'
+
+module BeakerAnswers
+  # This class provides answer file information for PE version 2017.2
+  #
+  # @api private
+  class Version20172 < Version20171
+    # The version of PE that this set of answers is appropriate for
+    def self.pe_version_matcher
+      /\A2017\.2/
+    end
+  end
+end

--- a/spec/beaker-answers/pe_conf_spec.rb
+++ b/spec/beaker-answers/pe_conf_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe 'BeakerAnswers::PeConf' do
+  let(:basic_hosts) { make_hosts({'pe_ver' => ver }, host_count) }
+
+  RSpec.shared_examples 'pe.conf configuration' do
+    context 'monolithic' do
+      let(:host_count) { 2 }
+      let(:hosts) do
+        basic_hosts[0]['roles'] = ['master', 'dashboard', 'database', 'agent']
+        basic_hosts[0]['platform'] = 'el-6-x86_64'
+        basic_hosts[1]['roles'] = ['agent']
+        basic_hosts[1]['platform'] = 'el-7-x86_64'
+        basic_hosts
+      end
+
+      it 'generates a hash of monolithic configuration data' do
+        expect(BeakerAnswers::PeConf.new(hosts, meep_schema_version).configuration_hash).to(
+          match(gold_mono_configuration_hash)
+        )
+      end
+    end
+
+    context 'split' do
+      let(:host_count) { 5 }
+      let(:hosts) do
+        basic_hosts[0]['roles'] = ['master', 'agent']
+        basic_hosts[0]['platform'] = 'el-6-x86_64'
+        basic_hosts[1]['roles'] = ['dashboard', 'agent']
+        basic_hosts[1]['platform'] = 'el-6-x86_64'
+        basic_hosts[2]['roles'] = ['database', 'agent']
+        basic_hosts[2]['platform'] = 'el-6-x86_64'
+        basic_hosts[3]['roles'] = ['agent']
+        basic_hosts[3]['platform'] = 'el-7-x86_64'
+        basic_hosts[4]['roles'] = ['agent']
+        basic_hosts[4]['platform'] = 'ubuntu-14.04-amd64'
+        basic_hosts
+      end
+
+      it 'generates a hash of split configuration data' do
+        expect(BeakerAnswers::PeConf.new(hosts, meep_schema_version).configuration_hash).to(
+          match(gold_split_configuration_hash)
+        )
+      end
+    end
+  end
+
+  context '1.0 schema' do
+    let(:ver)         { '2016.2.0' }
+    let(:meep_schema_version) { '1.0' }
+    let(:gold_mono_configuration_hash) do
+      {
+        "puppet_enterprise::puppet_master_host" => basic_hosts[0].hostname,
+      }
+    end
+    let(:gold_split_configuration_hash) do
+      {
+        "puppet_enterprise::puppet_master_host" => basic_hosts[0].hostname,
+        "puppet_enterprise::console_host" => basic_hosts[1].hostname,
+        "puppet_enterprise::puppetdb_host" => basic_hosts[2].hostname,
+      }
+    end
+
+    include_examples 'pe.conf configuration'
+  end
+
+  context '2.0 schema' do
+    let(:ver)         { '2017.2.0' }
+    let(:meep_schema_version) { '2.0' }
+    let(:gold_mono_configuration_hash) do
+      {
+        "node_roles" => {
+          "pe_role::monolithic::primary_master" => [basic_hosts[0].hostname],
+        },
+        "agent_platforms" => match_array(['el_6_x86_64', 'el_7_x86_64']),
+        "meep_schema_version" => "2.0",
+      }
+    end
+    let(:gold_split_configuration_hash) do
+      {
+        "node_roles" => {
+          "pe_role::split::primary_master" => [basic_hosts[0].hostname],
+          "pe_role::split::console" => [basic_hosts[1].hostname],
+          "pe_role::split::puppetdb" => [basic_hosts[2].hostname],
+        },
+        "agent_platforms" => match_array([
+          'el_6_x86_64',
+          'el_7_x86_64',
+          'ubuntu_1404_amd64'
+        ]),
+        "meep_schema_version" => "2.0",
+      }
+    end
+
+    include_examples 'pe.conf configuration'
+  end
+end

--- a/spec/beaker-answers/versions/version20171_spec.rb
+++ b/spec/beaker-answers/versions/version20171_spec.rb
@@ -10,18 +10,6 @@ describe BeakerAnswers::Version20171 do
     basic_hosts[0]['platform'] = 'el-7-x86_64'
     basic_hosts
   end
-  let(:split_hosts) do
-    basic_hosts = make_hosts({'pe_ver' => ver }, 4)
-    basic_hosts[0]['roles'] = ['master', 'agent']
-    basic_hosts[0]['platform'] = 'el-6-x86_64'
-    basic_hosts[1]['roles'] = ['dashboard', 'agent']
-    basic_hosts[1]['platform'] = 'el-6-x86_64'
-    basic_hosts[2]['roles'] = ['database', 'agent']
-    basic_hosts[2]['platform'] = 'el-6-x86_64'
-    basic_hosts[3]['roles'] = ['agent']
-    basic_hosts[3]['platform'] = 'ubuntu-14.04-amd64'
-    basic_hosts
-  end
   let(:answers)     { BeakerAnswers::Answers.create(ver, hosts, options) }
   let(:answer_hash) { answers.answers }
 
@@ -37,63 +25,6 @@ describe BeakerAnswers::Version20171 do
 
       include_examples 'pe.conf'
       include_examples 'valid MEEP 1.0 pe.conf'
-    end
-
-    context 'for a split install' do
-      let(:hosts) { split_hosts }
-      let( :gold_role_answers ) do
-        {
-          "console_admin_password" => default_password,
-          "puppet_enterprise::puppet_master_host" => hosts[0].hostname,
-          "puppet_enterprise::console_host" => hosts[1].hostname,
-          "puppet_enterprise::puppetdb_host" => hosts[2].hostname,
-        }
-      end
-
-      include_examples 'pe.conf'
-      include_examples 'valid MEEP 1.0 pe.conf'
-    end
-  end
-
-  context 'when generating a meep 2.0 config' do
-    before(:each) do
-      options[:meep_schema_version] = '2.0'
-    end
-
-    context 'for a monolithic install' do
-      let(:hosts) { mono_hosts }
-      let(:gold_role_answers) do
-        {
-          "console_admin_password" => default_password,
-          "node_roles" => {
-            "pe_role::monolithic::primary_master" => [hosts[0].hostname],
-          },
-          "agent_platforms" => match_array(['el_7_x86_64']),
-          "meep_schema_version" => "2.0",
-        }
-      end
-
-      include_examples 'pe.conf'
-      include_examples 'valid MEEP 2.0 pe.conf'
-    end
-
-    context 'for a split install' do
-      let(:hosts) { split_hosts }
-      let( :gold_role_answers ) do
-        {
-          "console_admin_password" => default_password,
-          "node_roles" => {
-            "pe_role::split::primary_master" => [hosts[0].hostname],
-            "pe_role::split::console" => [hosts[1].hostname],
-            "pe_role::split::puppetdb" => [hosts[2].hostname],
-          },
-          "agent_platforms" => match_array(['el_6_x86_64', 'ubuntu_1404_amd64']),
-          "meep_schema_version" => "2.0",
-        }
-      end
-
-      include_examples 'pe.conf'
-      include_examples 'valid MEEP 2.0 pe.conf'
     end
   end
 end

--- a/spec/beaker-answers/versions/version20171_spec.rb
+++ b/spec/beaker-answers/versions/version20171_spec.rb
@@ -2,45 +2,93 @@ require 'spec_helper'
 require 'json'
 
 describe BeakerAnswers::Version20171 do
-  let( :ver )         { '2017.1.0' }
-  let( :options )     { StringifyHash.new }
-  let( :basic_hosts ) { make_hosts( {'pe_ver' => ver } ) }
-  let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
-                  basic_hosts[1]['roles'] = ['dashboard', 'agent']
-                  basic_hosts[2]['roles'] = ['database', 'agent']
-                  basic_hosts }
-  let( :answers )     { BeakerAnswers::Answers.create(ver, hosts, options) }
-  let( :answer_hash ) { answers.answers }
+  let(:ver)         { '2017.1.0' }
+  let(:options)     { StringifyHash.new }
+  let(:mono_hosts) do
+    basic_hosts = make_hosts({'pe_ver' => ver }, 1)
+    basic_hosts[0]['roles'] = ['master', 'agent', 'dashboard', 'database']
+    basic_hosts[0]['platform'] = 'el-7-x86_64'
+    basic_hosts
+  end
+  let(:split_hosts) do
+    basic_hosts = make_hosts({'pe_ver' => ver }, 4)
+    basic_hosts[0]['roles'] = ['master', 'agent']
+    basic_hosts[0]['platform'] = 'el-6-x86_64'
+    basic_hosts[1]['roles'] = ['dashboard', 'agent']
+    basic_hosts[1]['platform'] = 'el-6-x86_64'
+    basic_hosts[2]['roles'] = ['database', 'agent']
+    basic_hosts[2]['platform'] = 'el-6-x86_64'
+    basic_hosts[3]['roles'] = ['agent']
+    basic_hosts[3]['platform'] = 'ubuntu-14.04-amd64'
+    basic_hosts
+  end
+  let(:answers)     { BeakerAnswers::Answers.create(ver, hosts, options) }
+  let(:answer_hash) { answers.answers }
 
-  context 'when generating a hiera config' do
+  context 'when generating a default 1.0 config' do
     context 'for a monolithic install' do
-      let( :basic_hosts ) { make_hosts( {'pe_ver' => ver }, 1 ) }
-      let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent', 'dashboard', 'database']
-                      basic_hosts }
-      let( :gold_role_answers ) do
+      let(:hosts) { mono_hosts }
+      let(:gold_role_answers) do
         {
           "console_admin_password" => default_password,
-          "node_roles" => {
-            "pe_role::monolithic::primary_master" => [basic_hosts[0].hostname],
-          }
+          "puppet_enterprise::puppet_master_host" => hosts[0].hostname,
         }
       end
 
-      it "accepts overrides to node_roles from beaker conf answers"
+      include_examples 'pe.conf'
+      include_examples 'valid MEEP 1.0 pe.conf'
+    end
+
+    context 'for a split install' do
+      let(:hosts) { split_hosts }
+      let( :gold_role_answers ) do
+        {
+          "console_admin_password" => default_password,
+          "puppet_enterprise::puppet_master_host" => hosts[0].hostname,
+          "puppet_enterprise::console_host" => hosts[1].hostname,
+          "puppet_enterprise::puppetdb_host" => hosts[2].hostname,
+        }
+      end
+
+      include_examples 'pe.conf'
+      include_examples 'valid MEEP 1.0 pe.conf'
+    end
+  end
+
+  context 'when generating a meep 2.0 config' do
+    before(:each) do
+      options[:meep_schema_version] = '2.0'
+    end
+
+    context 'for a monolithic install' do
+      let(:hosts) { mono_hosts }
+      let(:gold_role_answers) do
+        {
+          "console_admin_password" => default_password,
+          "node_roles" => {
+            "pe_role::monolithic::primary_master" => [hosts[0].hostname],
+          },
+          "agent_platforms" => match_array(['el_7_x86_64']),
+          "meep_schema_version" => "2.0",
+        }
+      end
 
       include_examples 'pe.conf'
       include_examples 'valid MEEP 2.0 pe.conf'
     end
 
     context 'for a split install' do
+      let(:hosts) { split_hosts }
       let( :gold_role_answers ) do
         {
           "console_admin_password" => default_password,
           "node_roles" => {
-            "pe_role::split::primary_master" => [basic_hosts[0].hostname],
-            "pe_role::split::console" => [basic_hosts[1].hostname],
-            "pe_role::split::puppetdb" => [basic_hosts[2].hostname],
-          }
+            "pe_role::split::primary_master" => [hosts[0].hostname],
+            "pe_role::split::console" => [hosts[1].hostname],
+            "pe_role::split::puppetdb" => [hosts[2].hostname],
+          },
+          "agent_platforms" => match_array(['el_6_x86_64', 'ubuntu_1404_amd64']),
+          "meep_schema_version" => "2.0",
         }
       end
 

--- a/spec/beaker-answers/versions/version20172_spec.rb
+++ b/spec/beaker-answers/versions/version20172_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+require 'json'
+
+describe BeakerAnswers::Version20172 do
+  let(:ver)         { '2017.2.0' }
+  let(:options)     { StringifyHash.new }
+  let(:mono_hosts) do
+    basic_hosts = make_hosts({'pe_ver' => ver }, 1)
+    basic_hosts[0]['roles'] = ['master', 'agent', 'dashboard', 'database']
+    basic_hosts[0]['platform'] = 'el-7-x86_64'
+    basic_hosts
+  end
+  let(:split_hosts) do
+    basic_hosts = make_hosts({'pe_ver' => ver }, 4)
+    basic_hosts[0]['roles'] = ['master', 'agent']
+    basic_hosts[0]['platform'] = 'el-6-x86_64'
+    basic_hosts[1]['roles'] = ['dashboard', 'agent']
+    basic_hosts[1]['platform'] = 'el-6-x86_64'
+    basic_hosts[2]['roles'] = ['database', 'agent']
+    basic_hosts[2]['platform'] = 'el-6-x86_64'
+    basic_hosts[3]['roles'] = ['agent']
+    basic_hosts[3]['platform'] = 'ubuntu-14.04-amd64'
+    basic_hosts
+  end
+  let(:answers)     { BeakerAnswers::Answers.create(ver, hosts, options) }
+  let(:answer_hash) { answers.answers }
+
+  context 'when generating a default 1.0 config' do
+    context 'for a monolithic install' do
+      let(:hosts) { mono_hosts }
+      let(:gold_role_answers) do
+        {
+          "console_admin_password" => default_password,
+          "puppet_enterprise::puppet_master_host" => hosts[0].hostname,
+        }
+      end
+
+      include_examples 'pe.conf'
+      include_examples 'valid MEEP 1.0 pe.conf'
+    end
+
+    context 'for a split install' do
+      let(:hosts) { split_hosts }
+      let( :gold_role_answers ) do
+        {
+          "console_admin_password" => default_password,
+          "puppet_enterprise::puppet_master_host" => hosts[0].hostname,
+          "puppet_enterprise::console_host" => hosts[1].hostname,
+          "puppet_enterprise::puppetdb_host" => hosts[2].hostname,
+        }
+      end
+
+      include_examples 'pe.conf'
+      include_examples 'valid MEEP 1.0 pe.conf'
+    end
+  end
+
+  context 'when generating a meep 2.0 config' do
+    before(:each) do
+      options[:meep_schema_version] = '2.0'
+    end
+
+    context 'for a monolithic install' do
+      let(:hosts) { mono_hosts }
+      let(:gold_role_answers) do
+        {
+          "console_admin_password" => default_password,
+          "node_roles" => {
+            "pe_role::monolithic::primary_master" => [hosts[0].hostname],
+          },
+          "agent_platforms" => match_array(['el_7_x86_64']),
+          "meep_schema_version" => "2.0",
+        }
+      end
+
+      include_examples 'pe.conf'
+      include_examples 'valid MEEP 2.0 pe.conf'
+    end
+
+    context 'for a split install' do
+      let(:hosts) { split_hosts }
+      let( :gold_role_answers ) do
+        {
+          "console_admin_password" => default_password,
+          "node_roles" => {
+            "pe_role::split::primary_master" => [hosts[0].hostname],
+            "pe_role::split::console" => [hosts[1].hostname],
+            "pe_role::split::puppetdb" => [hosts[2].hostname],
+          },
+          "agent_platforms" => match_array(['el_6_x86_64', 'ubuntu_1404_amd64']),
+          "meep_schema_version" => "2.0",
+        }
+      end
+
+      include_examples 'pe.conf'
+      include_examples 'valid MEEP 2.0 pe.conf'
+    end
+  end
+end

--- a/spec/shared/context.rb
+++ b/spec/shared/context.rb
@@ -57,7 +57,7 @@ RSpec.shared_examples 'pe.conf' do
   end
 
   it 'has just the role and values for default install' do
-    expect(answer_hash).to eq(
+    expect(answer_hash).to match(
       gold_role_answers
     )
   end
@@ -72,12 +72,12 @@ RSpec.shared_examples 'pe.conf' do
       end
 
       it 'has only the role values' do
-        expect(answer_hash).to eq(gold_role_answers)
+        expect(answer_hash).to match(gold_role_answers)
       end
 
       it 'also includes any explicitly added database parameters' do
         options.merge!(:answers => overridden_database_parameters)
-        expect(answer_hash).to eq(
+        expect(answer_hash).to match(
           gold_role_answers
             .merge(overridden_database_parameters)
         )
@@ -93,7 +93,7 @@ RSpec.shared_examples 'pe.conf' do
       end
 
       it 'has the role values and database defaults' do
-        expect(answer_hash).to eq(
+        expect(answer_hash).to match(
           gold_role_answers
             .merge(gold_db_answers)
         )
@@ -101,7 +101,7 @@ RSpec.shared_examples 'pe.conf' do
 
       it 'overrides defaults with explicitly added database parameters' do
         options.merge!(:answers => overridden_database_parameters)
-        expect(answer_hash).to eq(
+        expect(answer_hash).to match(
           gold_role_answers
             .merge(overridden_database_parameters)
         )
@@ -144,7 +144,7 @@ RSpec.shared_examples 'pe.conf' do
     end
 
     it 'matches expected answers' do
-      expect(answer_hash).to eq(gold_answers_with_overrides)
+      expect(answer_hash).to match(gold_answers_with_overrides)
     end
   end
 
@@ -163,7 +163,7 @@ RSpec.shared_examples 'pe.conf' do
     end
 
     it 'matches expected answers' do
-      expect(answer_hash).to eq(gold_answers_with_overrides)
+      expect(answer_hash).to match(gold_answers_with_overrides)
     end
   end
 end
@@ -173,7 +173,25 @@ RSpec.shared_examples "valid MEEP 2.0 pe.conf" do
     expect(answer_hiera).not_to be_empty
     expect { JSON.load(answer_hiera) }.not_to raise_error
     expect(answer_hiera).to match(%r{"node_roles"\s*:\s*\{})
-    expect(answer_hiera).to match(%r{"pe_role::\w+::primary_master"\s*:\s*\[\s*"#{basic_hosts[0].hostname}"\s*\]}m)
+    expect(answer_hiera).to match(%r{"pe_role::\w+::primary_master"\s*:\s*\[\s*"#{hosts[0].hostname}"\s*\]}m)
+  end
+
+  it 'sets the schema version' do
+    expect(answer_hash['meep_schema_version']).to eq('2.0')
+  end
+
+  context 'with beaker overrides' do
+    before(:each) do
+      options[:answers] = {
+        'pe_infrastructure::use_meep_for_classification' => true
+      }
+    end
+
+    it 'accepts overrides from beaker config' do
+      expect(answer_hiera).to match(
+        %r{"pe_infrastructure::use_meep_for_classification"\s*:\s*true}
+      )
+    end
   end
 end
 
@@ -181,6 +199,6 @@ RSpec.shared_examples "valid MEEP 1.0 pe.conf" do
   it 'generates valid MEEP 1.0 json if #answer_hiera is called' do
     expect(answer_hiera).not_to be_empty
     expect { JSON.load(answer_hiera) }.not_to raise_error
-    expect(answer_hiera).to match(%r{"puppet_enterprise::puppet_master_host"\s*:\s*"#{basic_hosts[0].hostname}"}m)
+    expect(answer_hiera).to match(%r{"puppet_enterprise::puppet_master_host"\s*:\s*"#{hosts[0].hostname}"}m)
   end
 end


### PR DESCRIPTION
and prepare Glisan.

Generate a meep 2.0 format based on version flag ￼…
Previously there was a hard version break set on PE 2017.1 which would
produce a 2.0 format pe.conf, but since we've had to back out meep
classification in Flanders, this needs to change.

Added a PeConf object to generate 1.0 and 2.0 format files based on a
meep_schema_version flag. It defaults to the original 1.0 format. It
will be up to beaker-pe to submit this flag in the beaker options based
on its use_meep_for_classification?() test.

There is one change to the 1.0 hiera_host_config implementation in that
it no longer uses answer_for to set the master, db, console settings. I
don't think this matters because there are no defaults for these
settings, and beaker answer overrides are merged afterwards in
generate_hiera_config() regardless.