### PR TITLE
(PE-19948) Fix pe_repo platform class for windows

### DIFF
--- a/lib/beaker-answers/pe_conf.rb
+++ b/lib/beaker-answers/pe_conf.rb
@@ -121,7 +121,11 @@ module BeakerAnswers
 
       # Collect a uniq array of all host platforms modified to pe_repo class format
       platforms = hosts.map do |h|
-        h['platform'].gsub(/-/, '_').gsub(/\./,'')
+        platform = h['platform']
+        if platform =~ /^windows.*/
+          platform = platform =~ /64/ ? 'windows_x86_64' : 'windows_i386'
+        end
+        platform.gsub(/-/, '_').gsub(/\./,'')
       end.uniq
       pe_conf["agent_platforms"] = platforms
 

--- a/spec/beaker-answers/pe_conf_spec.rb
+++ b/spec/beaker-answers/pe_conf_spec.rb
@@ -22,7 +22,7 @@ describe 'BeakerAnswers::PeConf' do
     end
 
     context 'split' do
-      let(:host_count) { 5 }
+      let(:host_count) { 6 }
       let(:hosts) do
         basic_hosts[0]['roles'] = ['master', 'agent']
         basic_hosts[0]['platform'] = 'el-6-x86_64'
@@ -34,6 +34,8 @@ describe 'BeakerAnswers::PeConf' do
         basic_hosts[3]['platform'] = 'el-7-x86_64'
         basic_hosts[4]['roles'] = ['agent']
         basic_hosts[4]['platform'] = 'ubuntu-14.04-amd64'
+        basic_hosts[5]['roles'] = ['agent']
+        basic_hosts[5]['platform'] = 'windows-2016-64'
         basic_hosts
       end
 
@@ -86,7 +88,8 @@ describe 'BeakerAnswers::PeConf' do
         "agent_platforms" => match_array([
           'el_6_x86_64',
           'el_7_x86_64',
-          'ubuntu_1404_amd64'
+          'ubuntu_1404_amd64',
+          'windows_x86_64',
         ]),
         "meep_schema_version" => "2.0",
       }


### PR DESCRIPTION
Before this commit the pe_repo platform class that would be generated
for all windows platforms would be incorrect as there is only a single
windows puppet agent. When this method would generate the list of
platform classes windows would be incorrect.

This commit ensures that when windows is a platform on a host we return
one of the two possible windows pe_repo platform classes.