### PR TITLE
(PE-22724) Add puppetdb startout timer for external postgres

### DIFF
--- a/lib/beaker-answers/pe_conf.rb
+++ b/lib/beaker-answers/pe_conf.rb
@@ -195,6 +195,7 @@ module BeakerAnswers
       when '1.0','2.0'
         pe_conf["puppet_enterprise::database_ssl"] = true
         pe_conf["puppet_enterprise::database_cert_auth"] = true
+        pe_conf["puppet_enterprise::puppetdb::start_timeout"] = 300
       end
       pe_conf
     end
@@ -202,6 +203,7 @@ module BeakerAnswers
     def postgres_password_answers(pe_conf, meep_schema_version)
       case meep_schema_version
       when '1.0','2.0'
+        pe_conf["puppet_enterprise::puppetdb::start_timeout"] = 300
         pe_conf["puppet_enterprise::activity_database_password"] = "PASSWORD"
         pe_conf["puppet_enterprise::classifier_database_password"] = "PASSWORD"
         pe_conf["puppet_enterprise::orchestrator_database_password"] = "PASSWORD"

--- a/spec/beaker-answers/pe_conf_spec.rb
+++ b/spec/beaker-answers/pe_conf_spec.rb
@@ -103,7 +103,8 @@ describe 'BeakerAnswers::PeConf' do
         "puppet_enterprise::database_cert_auth" => true,
         "puppet_enterprise::database_ssl" => true,
         "puppet_enterprise::puppet_master_host" => basic_hosts[0].hostname,
-        "puppet_enterprise::database_host" => basic_hosts[1].hostname
+        "puppet_enterprise::database_host" => basic_hosts[1].hostname,
+        "puppet_enterprise::puppetdb::start_timeout" => 300
       }
     end
     let(:gold_pe_postgres_password_configuration_hash) do
@@ -114,7 +115,8 @@ describe 'BeakerAnswers::PeConf' do
         "puppet_enterprise::puppetdb_database_password" => "PASSWORD",
         "puppet_enterprise::rbac_database_password" => "PASSWORD",
         "puppet_enterprise::puppet_master_host" => basic_hosts[0].hostname,
-        "puppet_enterprise::database_host" => basic_hosts[1].hostname
+        "puppet_enterprise::database_host" => basic_hosts[1].hostname,
+        "puppet_enterprise::puppetdb::start_timeout" => 300,
       }
     end
     include_examples 'pe.conf configuration'
@@ -142,6 +144,7 @@ describe 'BeakerAnswers::PeConf' do
         "meep_schema_version" => "2.0",
         "puppet_enterprise::database_cert_auth" => true,
         "puppet_enterprise::database_ssl" => true,
+        "puppet_enterprise::puppetdb::start_timeout" => 300
       }
     end
     let(:gold_pe_postgres_password_configuration_hash) do
@@ -157,6 +160,7 @@ describe 'BeakerAnswers::PeConf' do
         "puppet_enterprise::orchestrator_database_password" => "PASSWORD",
         "puppet_enterprise::puppetdb_database_password" => "PASSWORD",
         "puppet_enterprise::rbac_database_password" => "PASSWORD",
+        "puppet_enterprise::puppetdb::start_timeout" => 300
       }
     end
     let(:gold_split_configuration_hash) do


### PR DESCRIPTION
This setting was left out in my previous commit. Without this setting
on a monolithic install with PE managed external postgres, the
puppet database takes too long (25 minutes+) to time out. This causes
failures in Jenkins.
This answer that is added in will make the timeout only a few minutes
so hopefuly Jenkins wont abort the job.