### PR TITLE
(PE_22857) Set SSL settings to true for postgres

### DIFF
--- a/lib/beaker-answers/pe_conf.rb
+++ b/lib/beaker-answers/pe_conf.rb
@@ -203,8 +203,8 @@ module BeakerAnswers
     def postgres_password_answers(pe_conf, meep_schema_version)
       case meep_schema_version
       when '1.0','2.0'
-        pe_conf["puppet_enterprise::database_ssl"] = false
-        pe_conf["puppet_enterprise::database_cert_auth"] = false
+        pe_conf["puppet_enterprise::database_ssl"] = true
+        pe_conf["puppet_enterprise::database_cert_auth"] = true
         pe_conf["puppet_enterprise::puppetdb::start_timeout"] = 300
         pe_conf["puppet_enterprise::activity_database_password"] = "PASSWORD"
         pe_conf["puppet_enterprise::classifier_database_password"] = "PASSWORD"

--- a/spec/beaker-answers/pe_conf_spec.rb
+++ b/spec/beaker-answers/pe_conf_spec.rb
@@ -109,8 +109,8 @@ describe 'BeakerAnswers::PeConf' do
     end
     let(:gold_pe_postgres_password_configuration_hash) do
       {
-        "puppet_enterprise::database_cert_auth" => false,
-        "puppet_enterprise::database_ssl" => false,
+        "puppet_enterprise::database_cert_auth" => true,
+        "puppet_enterprise::database_ssl" => true,
         "puppet_enterprise::activity_database_password" => "PASSWORD",
         "puppet_enterprise::classifier_database_password" => "PASSWORD",
         "puppet_enterprise::orchestrator_database_password" => "PASSWORD",
@@ -157,8 +157,8 @@ describe 'BeakerAnswers::PeConf' do
         "puppet_enterprise::profile::database" => basic_hosts[1].hostname,
         "agent_platforms" => ['el_6_x86_64'],
         "meep_schema_version" => "2.0",
-        "puppet_enterprise::database_cert_auth" => false,
-        "puppet_enterprise::database_ssl" => false,
+        "puppet_enterprise::database_cert_auth" => true,
+        "puppet_enterprise::database_ssl" => true,
         "puppet_enterprise::activity_database_password" => "PASSWORD",
         "puppet_enterprise::classifier_database_password" => "PASSWORD",
         "puppet_enterprise::orchestrator_database_password" => "PASSWORD",


### PR DESCRIPTION
This PR sets databsae ssl and cert auth to true. This is required
for PE managed postgres installations.