### PR TITLE
(PE-24131) Disable puppet service management in pe.conf

### DIFF
--- a/lib/beaker-answers/versions/version20181.rb
+++ b/lib/beaker-answers/versions/version20181.rb
@@ -10,5 +10,18 @@ module BeakerAnswers
       /\A2018\.1/
     end
 
+    def generate_answers
+      the_answers = super
+
+      # New flag added in 2018.1.1
+      # Disable management of Puppet agent so that when Beaker stops the agent,
+      # it stays stopped. This will prevent flip-flops of configuration between 
+      # PE configure runs and agent runs.
+      # Needed for test: acceptance/tests/faces/enterprise/configure/idempotent.rb
+      the_answers['pe_infrastructure::agent::puppet_service_managed'] = false
+
+      the_answers
+    end
+
   end
 end

--- a/spec/beaker-answers/versions/version20181_spec.rb
+++ b/spec/beaker-answers/versions/version20181_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'json'
+
+describe BeakerAnswers::Version20181 do
+  let(:ver)         { '2018.1.0' }
+  let(:options)     { StringifyHash.new }
+  let(:mono_hosts) do
+    basic_hosts = make_hosts({'pe_ver' => ver }, 1)
+    basic_hosts[0]['roles'] = ['master', 'agent', 'dashboard', 'database']
+    basic_hosts[0]['platform'] = 'el-7-x86_64'
+    basic_hosts
+  end
+  let(:answers)     { BeakerAnswers::Answers.create(ver, hosts, options) }
+  let(:answer_hash) { answers.answers }
+
+  context 'when generating a default 1.0 config' do
+    context 'for a monolithic install' do
+      let(:hosts) { mono_hosts }
+      let(:gold_role_answers) do
+        {
+          "console_admin_password" => default_password,
+          "puppet_enterprise::puppet_master_host" => hosts[0].hostname,
+          "pe_infrastructure::agent::puppet_service_managed" => false,
+        }
+      end
+
+      include_examples 'pe.conf'
+      include_examples 'valid MEEP 1.0 pe.conf'
+    end
+  end
+
+  context 'when generating a meep 2.0 config' do
+    before(:each) do
+      options[:meep_schema_version] = '2.0'
+    end
+
+    context 'for a monolithic install' do
+      let(:hosts) { mono_hosts }
+      let(:gold_role_answers) do
+        {
+          "console_admin_password" => default_password,
+          "node_roles" => {
+            "pe_role::monolithic::primary_master" => [hosts[0].hostname],
+          },
+          "agent_platforms" => match_array(['el_7_x86_64']),
+          "pe_infrastructure::agent::puppet_service_managed" => false,
+          "meep_schema_version" => "2.0",
+        }
+      end
+
+      include_examples 'pe.conf'
+      include_examples 'valid MEEP 2.0 pe.conf'
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the new flag (added 2018.1.1) `puppet_service_managed`
which is set to false. This will allow Beaker to stop the puppet service
and for it to remain stopped if `puppet infra configure` is run
post-installation.