### PR TITLE
PE-25811 Use ssl based auth as default for external postgres node

### DIFF
--- a/lib/beaker-answers/pe_conf.rb
+++ b/lib/beaker-answers/pe_conf.rb
@@ -91,7 +91,7 @@ module BeakerAnswers
             postgres_password_answers(pe_conf, '1.0')
           end
         else
-          postgres_password_answers(pe_conf, '1.0')
+          postgres_cert_answers(pe_conf, '1.0')
         end
       end
 


### PR DESCRIPTION
When setting up external postgres node use ssl based cert auth as the
default instead of password based auth