### PR TITLE
Remove markdown dependency

### DIFF
--- a/beaker-answers.gemspec
+++ b/beaker-answers.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'markdown'
   s.add_development_dependency 'thin'
 
   # Run time dependencies


### PR DESCRIPTION
    Removing markdown from depndencies as this is not currently used. With
    markdown, unit tests are failing in jenkins with older versions of ruby
    that can't handle markdown's dependencies.