### PR TITLE
(maint) Fix overly permissive version checking and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ key concepts.
 # Release
 
 To release a new version, we use a
-[Jenkins job](https://cinext-jenkinsmaster-sre-prod-1.delivery.puppetlabs.net/view/beaker%20Release%20Jobs/job/qe_beaker-answers_init-multijob_master/)
+[Jenkins job](https://cinext-jenkinsmaster-sre-prod-1.delivery.puppetlabs.net/view/beaker%20Release%20Jobs/job/qe_beaker-answers_init-multijob_main/)
 (access to internal infrastructure will be required to view job).
 
-To release a new version (from the master branch), you'll need to just provide
+To release a new version (from the main branch), you'll need to just provide
 a new beaker-answers version number to the job, and you're off to the races.
 
 # Questions

--- a/lib/beaker-answers/versions/version20173.rb
+++ b/lib/beaker-answers/versions/version20173.rb
@@ -7,7 +7,7 @@ module BeakerAnswers
   class Version20173to9999 < Version20172
     # The version of PE that this set of answers is appropriate for
     def self.pe_version_matcher
-      /\A(2017\.3|2018\.[1-2]|2019\.[0-9]|20[2-9][1-9]\.[0-9]|[2-9][0-9]{3}\.[0-9])/
+      /\A(2017\.3|2018\.[1-2]|2019\.[0-9]|20[2-9][1-9]\.[0-9])/
     end
   end
 end

--- a/spec/beaker-answers/versions/version20173_spec.rb
+++ b/spec/beaker-answers/versions/version20173_spec.rb
@@ -18,8 +18,6 @@ describe BeakerAnswers::Version20173to9999 do
     '2029.0.0',
     '2099.0.0',
     '2099.99.99',
-    '9999.0.0',
-    '9999.99.99',
   ]
 
   versions.each do | version |


### PR DESCRIPTION
A patch was made so that beaker-answers would support any version past 2017.3 without requiring changes to this library each time a new release was created. However, the regex used to detect versions up to 9999.9.99 caused it to also match pre-2017.3 versions, which could cause unsupported answers to be used. This constrains the version checking to limit the maximum version to 2099.9.99. We'll probably all be dead by then, along with this code.