### PR TITLE
(maint) remove optional 'bodyfile' input from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
       with:
         tag: ${{ steps.nv.outputs.version }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        bodyfile: release-notes.md
         draft: false
         prerelease: false
 


### PR DESCRIPTION
We don't need autogenerated release notes for this repo so this action input should not be included.